### PR TITLE
Allow O2OpenAccess to find missing dependencies

### DIFF
--- a/cmake/FindLibUV.cmake
+++ b/cmake/FindLibUV.cmake
@@ -1,0 +1,125 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+FindLibUV
+---------
+
+Find libuv includes and library.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+An :ref:`imported target <Imported targets>` named
+``LibUV::LibUV`` is provided if libuv has been found.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module defines the following variables:
+
+``LibUV_FOUND``
+  True if libuv was found, false otherwise.
+``LibUV_INCLUDE_DIRS``
+  Include directories needed to include libuv headers.
+``LibUV_LIBRARIES``
+  Libraries needed to link to libuv.
+``LibUV_VERSION``
+  The version of libuv found.
+``LibUV_VERSION_MAJOR``
+  The major version of libuv.
+``LibUV_VERSION_MINOR``
+  The minor version of libuv.
+``LibUV_VERSION_PATCH``
+  The patch version of libuv.
+
+Cache Variables
+^^^^^^^^^^^^^^^
+
+This module uses the following cache variables:
+
+``LibUV_LIBRARY``
+  The location of the libuv library file.
+``LibUV_INCLUDE_DIR``
+  The location of the libuv include directory containing ``uv.h``.
+
+The cache variables should not be used by project code.
+They may be set by end users to point at libuv components.
+#]=======================================================================]
+
+#-----------------------------------------------------------------------------
+find_library(LibUV_LIBRARY
+  NAMES uv libuv
+  PATHS $ENV{LIBUV_ROOT}/lib
+  )
+mark_as_advanced(LibUV_LIBRARY)
+
+find_path(LibUV_INCLUDE_DIR
+  NAMES uv.h
+  PATHS $ENV{LIBUV_ROOT}/include
+  )
+mark_as_advanced(LibUV_INCLUDE_DIR)
+
+#-----------------------------------------------------------------------------
+# Extract version number if possible.
+set(_LibUV_H_REGEX "#[ \t]*define[ \t]+UV_VERSION_(MAJOR|MINOR|PATCH)[ \t]+[0-9]+")
+if(LibUV_INCLUDE_DIR AND EXISTS "${LibUV_INCLUDE_DIR}/uv-version.h")
+  file(STRINGS "${LibUV_INCLUDE_DIR}/uv-version.h" _LibUV_H REGEX "${_LibUV_H_REGEX}")
+elseif(LibUV_INCLUDE_DIR AND EXISTS "${LibUV_INCLUDE_DIR}/uv/version.h")
+  file(STRINGS "${LibUV_INCLUDE_DIR}/uv/version.h" _LibUV_H REGEX "${_LibUV_H_REGEX}")
+elseif(LibUV_INCLUDE_DIR AND EXISTS "${LibUV_INCLUDE_DIR}/uv.h")
+  file(STRINGS "${LibUV_INCLUDE_DIR}/uv.h" _LibUV_H REGEX "${_LibUV_H_REGEX}")
+else()
+  set(_LibUV_H "")
+endif()
+foreach(c MAJOR MINOR PATCH)
+  if(_LibUV_H MATCHES "#[ \t]*define[ \t]+UV_VERSION_${c}[ \t]+([0-9]+)")
+    set(_LibUV_VERSION_${c} "${CMAKE_MATCH_1}")
+  else()
+    unset(_LibUV_VERSION_${c})
+  endif()
+endforeach()
+if(DEFINED _LibUV_VERSION_MAJOR AND DEFINED _LibUV_VERSION_MINOR)
+  set(LibUV_VERSION_MAJOR "${_LibUV_VERSION_MAJOR}")
+  set(LibUV_VERSION_MINOR "${_LibUV_VERSION_MINOR}")
+  set(LibUV_VERSION "${LibUV_VERSION_MAJOR}.${LibUV_VERSION_MINOR}")
+  if(DEFINED _LibUV_VERSION_PATCH)
+    set(LibUV_VERSION_PATCH "${_LibUV_VERSION_PATCH}")
+    set(LibUV_VERSION "${LibUV_VERSION}.${LibUV_VERSION_PATCH}")
+  else()
+    unset(LibUV_VERSION_PATCH)
+  endif()
+else()
+  set(LibUV_VERSION_MAJOR "")
+  set(LibUV_VERSION_MINOR "")
+  set(LibUV_VERSION_PATCH "")
+  set(LibUV_VERSION "")
+endif()
+unset(_LibUV_VERSION_MAJOR)
+unset(_LibUV_VERSION_MINOR)
+unset(_LibUV_VERSION_PATCH)
+unset(_LibUV_H_REGEX)
+unset(_LibUV_H)
+
+#-----------------------------------------------------------------------------
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(LibUV
+  FOUND_VAR LibUV_FOUND
+  REQUIRED_VARS LibUV_LIBRARY LibUV_INCLUDE_DIR
+  VERSION_VAR LibUV_VERSION
+  )
+set(LIBUV_FOUND ${LibUV_FOUND})
+
+#-----------------------------------------------------------------------------
+# Provide documented result variables and targets.
+if(LibUV_FOUND)
+  set(LibUV_INCLUDE_DIRS ${LibUV_INCLUDE_DIR})
+  set(LibUV_LIBRARIES ${LibUV_LIBRARY})
+  if(NOT TARGET LibUV::LibUV)
+    add_library(LibUV::LibUV UNKNOWN IMPORTED)
+    set_target_properties(LibUV::LibUV PROPERTIES
+      IMPORTED_LOCATION "${LibUV_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES "${LibUV_INCLUDE_DIRS}"
+      )
+  endif()
+endif()

--- a/cmake/FindRapidJSON.cmake
+++ b/cmake/FindRapidJSON.cmake
@@ -1,0 +1,42 @@
+# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# All rights not expressly granted are reserved.
+#
+# This software is distributed under the terms of the GNU General Public
+# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+#
+# Finds the rapidjson (header-only) library using the CONFIG file provided by
+# RapidJSON and add the RapidJSON::RapidJSON imported targets on top of it
+#
+
+find_package(RapidJSON CONFIG QUIET)
+
+if(RapidJSON_FOUND AND RAPIDJSON_INCLUDE_DIRS AND NOT RapidJSON_INCLUDE_DIR)
+  set(RapidJSON_INCLUDE_DIR ${RAPIDJSON_INCLUDE_DIRS})
+endif()
+
+if(NOT RapidJSON_INCLUDE_DIR)
+  set(RapidJSON_FOUND FALSE)
+  if(RapidJSON_FIND_REQUIRED)
+    message(FATAL_ERROR "RapidJSON not found")
+  endif()
+else()
+  set(RapidJSON_FOUND TRUE)
+endif()
+
+mark_as_advanced(RapidJSON_INCLUDE_DIR)
+
+get_filename_component(inc ${RapidJSON_INCLUDE_DIR} ABSOLUTE)
+
+if(RapidJSON_FOUND AND NOT TARGET RapidJSON::RapidJSON)
+  add_library(RapidJSON::RapidJSON IMPORTED INTERFACE)
+  set_target_properties(RapidJSON::RapidJSON
+                        PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${inc})
+endif()
+
+unset(inc)


### PR DESCRIPTION
Something is probably wrong in the way O2 exports some dependencies, however this allows me to workaround the issue.